### PR TITLE
BUG: fix convex hull intersection to compute MLP

### DIFF
--- a/pctProtonPairsToBackProjection.txx
+++ b/pctProtonPairsToBackProjection.txx
@@ -206,7 +206,7 @@ ProtonPairsToBackProjection<TInputImage, TOutputImage>
           if(m_QuadricIn.GetPointer()!=NULL)
             {
             if(m_QuadricIn->IsIntersectedByRay(pIn,dIn,nearDistIn,farDistIn) &&
-               m_QuadricOut->IsIntersectedByRay(pOut,dOut,nearDistOut,farDistOut))
+               m_QuadricOut->IsIntersectedByRay(pOut,dOut,farDistOut,nearDistOut))
               {
               pSIn  = pIn  + dIn  * nearDistIn;
               if(pSIn[2]<pIn[2]  || pSIn[2]>pOut[2])

--- a/pctProtonPairsToDistanceDrivenProjection.txx
+++ b/pctProtonPairsToDistanceDrivenProjection.txx
@@ -263,7 +263,7 @@ ProtonPairsToDistanceDrivenProjection<TInputImage, TOutputImage>
     if(m_QuadricIn.GetPointer()!=NULL)
       {
       if(m_QuadricIn->IsIntersectedByRay(pIn,dIn,nearDistIn,farDistIn) &&
-         m_QuadricOut->IsIntersectedByRay(pOut,dOut,nearDistOut,farDistOut))
+         m_QuadricOut->IsIntersectedByRay(pOut,dOut,farDistOut,nearDistOut))
         {
         QuadricIntersected = true;
         pSIn  = pIn  + dIn  * nearDistIn;

--- a/pctmostlikelypath.cxx
+++ b/pctmostlikelypath.cxx
@@ -72,7 +72,7 @@ int main(int argc, char * argv[])
   if(args_info.quadricIn_given &&
      args_info.quadricOut_given &&
      quadricIn->IsIntersectedByRay(pIn,dIn,nearDistIn,farDistIn) &&
-     quadricOut->IsIntersectedByRay(pOut,dOut,nearDistOut,farDistOut))
+     quadricOut->IsIntersectedByRay(pOut,dOut,farDistOut,nearDistOut))
     {
     pSIn  = pIn  + dIn  * nearDistIn;
     if(pSIn[2]<pIn[2]  || pSIn[2]>pOut[2])


### PR DESCRIPTION
Since SimonRit/RTK@009ef926de7aebf2974024bee633e40403078084, the ray
quadric intersection returns ordered distances so for the exit position,
the two distances are negative and the order should be swapped.